### PR TITLE
Use object reference instead of method reference (instantiate object)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,18 +101,18 @@ module.exports = {
            * If Model Action exists, create action instance
            */
           if (!mixinsKit.model && model.action) {
-            model.action = model.action[model.name][model.type];
+            model.action = model.action[model.name];
 
             /**
              * If mixinsKit Model exists, create action instance
              */
           } else if (mixinsKit.model && !model.action) {
-            model.action = mixinsKit.model[model.name][model.type];
+            model.action = mixinsKit.model[model.name];
           }
 
           //Create call
           return model
-            .action(query)
+            .action[model.type](query)
             .populate(model.populate)
             .select(model.select);
         }


### PR DESCRIPTION
## What does this do?

As it was before
```
model.action = model.action[model.name][model.type];

model.action(query)
```
yields an error because it calls a function which belongs to a class, the reference must come from an object which contains the function.